### PR TITLE
wdt: Add support for `archlinux` `base-devel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Distros that are available on the Microsoft Store are really quite limited and f
 This script generates WSL2 importable minimal tarballs that are extracted from docker containers.
 At the moment only a few distributions are exported. These include:
 * Alpine Linux (Latest and Edge)
-* Arch Linux
+* Arch Linux (Stable and base-devel)
 * CentOS
 * Clear Linux
 * Debian (Stable and Unstable with slim variants)

--- a/wsl-tar-gen.sh
+++ b/wsl-tar-gen.sh
@@ -30,6 +30,7 @@ DISTROS=(
     "alpine:latest"
     "alpine:edge"
     "archlinux"
+    "archlinux:base-devel"
     "centos"
     "clearlinux"
     "debian"


### PR DESCRIPTION
* base-devel is a package group that includes tools needed for building (compiling and linking). It is not necessary for a basic install, and many users don't need to install it. If you find it useful, you can either install it as part of your basic install, or later.


Change-Id: I87a6cdd311f131698e8656fdecf1bedb9c73ea98