### PR TITLE
Deprecate CentOS and add support for AlmaLinux OS and Rocky Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Distros that are available on the Microsoft Store are really quite limited and f
 This script generates WSL2 importable minimal tarballs that are extracted from docker containers.
 At the moment only a few distributions are exported. These include:
 * Adélie Linux
+* AlmaLinux OS
 * Alpine Linux (Latest and Edge)
 * Arch Linux (Stable and base-devel)
 * CentOS

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ At the moment only a few distributions are exported. These include:
 * Gentoo (Latest stage3 tarballs)
 * Kali Linux (Rolling release)
 * openSUSE Tumbleweed
+* Rocky Linux 9
 * Ubuntu (Stable and Bleeding edge [devel])
 
 Grab the latest tarballs of your favourite distro from the [Releases Page](https://github.com/mvaisakh/wsl-distro-tars/releases)!

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ At the moment only a few distributions are exported. These include:
 * AlmaLinux OS
 * Alpine Linux (Latest and Edge)
 * Arch Linux (Stable and base-devel)
-* CentOS
 * Clear Linux
 * Debian (Stable and Unstable with slim variants)
 * Fedora (Stable and Rawhide)

--- a/wsl-tar-gen.sh
+++ b/wsl-tar-gen.sh
@@ -28,6 +28,8 @@ mkdir -p "$TAR_DIR"
 # parse desired distro
 DISTROS=(
     "adelielinux/adelie"
+    "almalinux:latest"
+    "almalinux:minimal"
     "alpine:latest"
     "alpine:edge"
     "archlinux"

--- a/wsl-tar-gen.sh
+++ b/wsl-tar-gen.sh
@@ -44,6 +44,8 @@ DISTROS=(
     "gentoo/stage3:systemd"
     "kalilinux/kali-rolling"
     "opensuse/tumbleweed"
+    "rockylinux:9"
+    "rockylinux:9-minimal"
     "ubuntu"
     "ubuntu:devel"
 )

--- a/wsl-tar-gen.sh
+++ b/wsl-tar-gen.sh
@@ -34,7 +34,6 @@ DISTROS=(
     "alpine:edge"
     "archlinux"
     "archlinux:base-devel"
-    "centos"
     "clearlinux"
     "debian"
     "debian:stable-slim"


### PR DESCRIPTION
Hi @mvaisakh,

Proposing that WDT drops support for CentOS and provides Rocky Linux 9 and AlmaLinux OS as alternates.

From [CentOS docker repository](https://hub.docker.com/_/centos)

> DEPRECATION NOTICE
> All tags of this image are EOL ([June 30, 2024⁠](https://www.redhat.com/en/topics/linux/centos-linux-eol)
/ [docker-library/official-images#17094⁠](https://github.com/docker-library/official-images/pull/17094), although the last meaningful update was November 16, 2020, long before the EOL date: [docker-library/official-images#9102⁠](https://github.com/docker-library/official-images/pull/9102); see also [https://www.centos.org/centos-linux-eol/⁠](https://www.centos.org/centos-linux-eol/) and [docker-library/docs#2205⁠](https://github.com/docker-library/docs/pull/2205)). Please adjust your usage accordingly.



